### PR TITLE
Removed non-existant win64 option for os.platform

### DIFF
--- a/content/post/writing-cross-platform-node.md
+++ b/content/post/writing-cross-platform-node.md
@@ -135,10 +135,9 @@ Thanks to [indexzero][7] for this tip.
 If you need even more control you can get the operating system platform and CPU architecture you are running on react accordingly with the [os module][3].
 
     var os = require('os');
-    os.platform();
+    os.platform(); // equivalent to process.platform
     // 'linux' on Linux
-    // 'win32' on Windows 32-bit
-    // 'win64' on Windows 64-bit
+    // 'win32' on Windows (32-bit / 64-bit)
     // 'darwin' on OSX
     os.arch();
     // 'x86' on 32-bit CPU architecture


### PR DESCRIPTION
Per https://nodejs.org/api/os.html#os_os_platform, `process.env.platform` and `require('os').platform()` are equivalent.  Although the name is confusing, `win32` refers to all Windows architectures and can be reliably used to detect Windows.