### PR TITLE
Update vim-statuslines.md

### DIFF
--- a/content/post/vim-statuslines.md
+++ b/content/post/vim-statuslines.md
@@ -87,7 +87,9 @@ Colour is perhaps the hardest part to configure in statuslines. [The documentati
 After reading the documentation and understanding how statuslines work it was easy to construct a statusline that works for me.
 
     function! GitBranch()
-      return system("git rev-parse --abbrev-ref HEAD 2>/dev/null | tr -d '\n'")
+      let fpath = expand('%:h')
+      let gitcmd = "cd ".fpath." && git rev-parse --abbrev-ref HEAD 2>/dev/null | tr -d '\n'"
+      return system(gitcmd)
     endfunction
 
     function! StatuslineGit()


### PR DESCRIPTION
The current GitBranch function will display a branch name for the current directory where Vim was launched even if a file is opened in a different directory outside of the git repository.  For example, when editing my ~/.vimrc the status line showed a git branch of "master" even though my .vimrc file in my home directory is not a part of a git repository.  This revision changes the command to cd to the open file's directory and detects the branch name from there.  

Also noted that command assumes the current file being edited is actually a committed member of the branch.