### PR TITLE
Use correct path to file

### DIFF
--- a/content/post/zsh-corrupt-history-file.md
+++ b/content/post/zsh-corrupt-history-file.md
@@ -37,7 +37,7 @@ Once this happened more than twice I made a script to fix the issue. The followi
     # Fixes a corrupt .zsh_history file
 
     mv ~/.zsh_history ~/.zsh_history_bad
-    strings .zsh_history_bad > .zsh_history
+    strings ~/.zsh_history_bad > ~/.zsh_history
     fc -R ~/.zsh_history
     rm ~/.zsh_history_bad
 


### PR DESCRIPTION
The path in the blog post for `.zsh_history`, was not correct , causing the script to fail.

I think this also applies for [https://github.com/shapeshed/dotfiles/blob/master/bin/zsh_history_fix](https://github.com/shapeshed/dotfiles/blob/master/bin/zsh_history_fix)