### PR TITLE
Fix for file count on unix-wc.md

### DIFF
--- a/content/posts/unix-wc.md
+++ b/content/posts/unix-wc.md
@@ -65,7 +65,7 @@ Done. There are 1866 records across the 5 files.
 
 To count the number of folders and files in a directory `wc` can be combined with the `ls` command. By passing the `-l` options to `ls` it will each folder or line on a new line. This can be piped to `wc` to give a count. 
 
-    ls -l | wc -l
+    ls -1 | wc -l
     21
 
 ## Further reading


### PR DESCRIPTION
In order to count the files you need to use the flag "-1" (one in digit) because if you use "-l" (letter L), the command ls will print the header as well as all the file listed.

Example
$ ls -l
total 24
drwxr-xr-x 2 root root 4096 Jan 16 16:59 conf.avail
drwxr-xr-x 2 root root 4096 Jan 16 16:59 conf.d
-rw-r--r-- 1 root root 2847 Oct 14 14:36 fonts.conf
-rw-r--r-- 1 root root 8248 Oct 14 14:36 fonts.dtd

This will result in 5 lines if piped to "wc -l" while if you run:
$ ls -1
conf.avail
conf.d
fonts.conf
fonts.dtd

will result in 4 lines.

Thank you for your contribution! You are helping a community of over 10,000 daily readers.

