### PR TITLE
Add example function to repair corrupt ZSH history

### DIFF
--- a/content/posts/zsh-corrupt-history-file.md
+++ b/content/posts/zsh-corrupt-history-file.md
@@ -48,6 +48,30 @@ If you'd like the script you can download it directly from Github, put it somewh
     cd ~/bin # or somewhere in your $PATH
     wget https://raw.githubusercontent.com/shapeshed/dotfiles/master/bin/zsh_history_fix
     chmod +x zsh_history_fix
+    
+In the alternative, a ZSH function can be defined in place of using a script. This may be useful if, e.g., you prefer to maintain a single file containing multiple user-defined functions that is sourced on ZSH startup. Be advised that this approach will consume more memory, as sourcing the file containing the function will cause the function to stay resident in memory even when not in use.
+
+This version of the function assumes the history file is located at the globally defined variable $HISTFILE, which means it should be able to find the history file on any system where this variable is defined. This approach should also work in a shell script.
+
+Also note that this function includes extra print statements and comments that are not necessary, but that help demonstrate what is going on and may be useful if you are just learning shell/ZSH programming. Everything before the mv command and after the rm command is optional.
+
+    function fixCorruptHistoryFile
+    {
+        local historyPath=$HISTFILE:h               # Get file path without file name
+        local historyFile=$HISTFILE:t               # Get file name
+
+        print -P "Repairing corrupt ZSH History File at:" $historyPath "..."
+        print -P "ZSH History File is:" $historyFile
+
+        # Repair logic
+        print -P "Starting repair..."
+        mv $historyPath"/"$historyFile $historyPath"/"$historyFile"_corrupted"
+        strings $historyPath"/"$historyFile"_corrupted" > $historyPath"/"$historyFile
+        fc -R $historyPath"/"$historyFile
+        print -P "Repair complete."
+        rm $historyPath"/"$historyFile"_corrupted"
+        print -P "Temporary repair file deleted. Function terminated."
+    }
 
 [1]: http://www.zsh.org/
 [2]: https://shapeshed.com/unix-fc/

--- a/content/posts/zsh-corrupt-history-file.md
+++ b/content/posts/zsh-corrupt-history-file.md
@@ -53,7 +53,7 @@ In the alternative, a ZSH function can be defined in place of using a script. Th
 
 This version of the function assumes the history file is located at the globally defined variable $HISTFILE, which means it should be able to find the history file on any system where this variable is defined. This approach should also work in a shell script.
 
-Also note that this function includes extra print statements and comments that are not necessary, but that help demonstrate what is going on and may be useful if you are just learning shell/ZSH programming. Everything before the mv command and after the rm command is optional.
+Also note that this function includes extra print statements and comments that are not necessary, but that help demonstrate what is going on and may be useful if you are just learning shell/ZSH programming. Except for the local variable definitions, everything before the mv command and after the rm command is optional.
 
     function fixCorruptHistoryFile
     {


### PR DESCRIPTION
Hello!

Thank you for this article. I ended up with a getting this exact error after my Pi hard crashed, and I had no idea what to do. Luckily, your article was the first thing that came up in Google. I really appreciate how easy you made it to understand the problem and the fix.

I'm just learning scripting and function writing in ZSH/Bash, and wanted to try to turn the script into a function, with added logic for locating the history file based on a defined $HISTFILE variable, which can be set as part of the standard ZSH setup on a new install. (It is set when a user runs ZSH for the first time after installing ZSH--or at least it is in the Arch Linux/Manjaro ARM version of ZSH.) Alternatively, it can be manually set or changed at any time if you want to move your ZSH history file from the default location.

This is what I came up with and I wanted to share it in case someone might find it useful. I understand if it's not something you want to add to the article, though. :)

As I'm writing this comment, I realize that one potential issue is that the function might break if the user changes the value of $HISTFILE and does not reload/re-source the file containing the function. I don't know enough about ZSH/shell programming yet to know if there's a way to protect against that, beyond trusting the user not to do it.


