### PR TITLE
Update zsh-corrupt-history-file.md

### DIFF
--- a/content/posts/zsh-corrupt-history-file.md
+++ b/content/posts/zsh-corrupt-history-file.md
@@ -36,7 +36,8 @@ Once this happened more than twice I made a script to fix the issue. The followi
 
     mv ~/.zsh_history ~/.zsh_history_bad
     strings -eS ~/.zsh_history_bad > ~/.zsh_history
-    fc -R ~/.zsh_history
+    #R in capital gives an error so the solution
+    fc -r ~/.zsh_history
     rm ~/.zsh_history_bad
 
 Now if I see the `zsh: corrupt history file` error again I just run the command get back to work.


### PR DESCRIPTION
The command fc does not recognize the parameter -R, the change is just to put it with a lowercase -r and it does the trick. I bet it was working before but we got to keep up with updates. This was noticed on my kali linux version ==> 5.10.0-kali3

Thanks for the script it helped me alot

